### PR TITLE
Add `sort` param to `buildQueryBodyFromFilterObject` and defaults to `SearchQuery` constructor

### DIFF
--- a/src/elasticsearch/index.ts
+++ b/src/elasticsearch/index.ts
@@ -38,7 +38,7 @@ export function applySort ({ sort, queryChain }: { sort: any, queryChain:any }):
  * Build a elasticsearch request-body from unified query object (as known from `storefront-api`) - eg: `{ "type_id": { "eq": "configurable "} }`
  * @return {Object} Elasticsearch request body
  */
-export async function buildQueryBodyFromFilterObject ({ config, queryChain, filter, search = '' }: { config: ElasticsearchQueryConfig, queryChain: any, filter: any, search: string }): Promise<any> {
+export async function buildQueryBodyFromFilterObject ({ config, queryChain, filter, sort, search = '' }: { config: ElasticsearchQueryConfig, queryChain: any, filter: any, sort: any, search: string }): Promise<any> {
   function processNestedFieldFilter (attribute: string, value: any) {
     let processedFilter = {
       'attribute': attribute,
@@ -74,6 +74,7 @@ export async function buildQueryBodyFromFilterObject ({ config, queryChain, filt
     searchQuery: new SearchQuery({
       _appliedFilters: appliedFilters,
       _availableFilters: appliedFilters,
+      _appliedSort: sort,
       _searchText: search
     })
   })

--- a/src/types/SearchQuery.ts
+++ b/src/types/SearchQuery.ts
@@ -15,10 +15,10 @@ export default class SearchQuery {
     if (!queryObj) {
       queryObj = { _availableFilters: [], _appliedFilters: [], _appliedSort: [], _searchText: '' } 
     }
-    this._availableFilters = queryObj._availableFilters
-    this._appliedFilters = queryObj._appliedFilters
-    this._appliedSort = queryObj._appliedSort
-    this._searchText = queryObj._searchText
+    this._availableFilters = queryObj._availableFilters || []
+    this._appliedFilters = queryObj._appliedFilters || []
+    this._appliedSort = queryObj._appliedSort || []
+    this._searchText = queryObj._searchText || ''
   }
   /**
     * @return {Array} array of all available filters objects


### PR DESCRIPTION
Closes #7

Add `_appliedSort`/`sort` param to `buildQueryBodyFromFilterObject` method and defaults to params of `SearchQuery` constructor.