### PR TITLE
Support aggregation size option in `_availableFilters`

### DIFF
--- a/src/elasticsearch/body.ts
+++ b/src/elasticsearch/body.ts
@@ -298,8 +298,9 @@ export default class RequestBody {
       for (let attribute of filters) {
         if (this.checkIfObjectHasScope({ object: attribute, scope: 'catalog' })) {
           const { field } = attribute
+          const options = attribute.options || {}
           if (field !== 'price') {
-            let aggregationSize = { size: config.filterAggregationSize[field] || config.filterAggregationSize.default }
+            let aggregationSize = { size: options.size || config.filterAggregationSize[field] || config.filterAggregationSize.default }
             this.queryChain
               .aggregation('terms', this.getMapping(field), aggregationSize)
               .aggregation('terms', field + this.optionsPrefix, aggregationSize)


### PR DESCRIPTION
It's possible to add `options` to the `AvailableFilter` objects. If you add size to have a custom aggregation size/limit it won't be applied as the option parameter intends. This is to support custom aggregation sizes by query and not just by global configurations in `products.filterAggregationSize` setting.